### PR TITLE
Question Types and Review Page

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.20.0",
     "react-scripts": "^5.0.1",
+    "react-spinners": "^0.13.8",
     "sass": "^1.69.5",
     "typescript": "^4.4.2",
     "web-vitals": "^2.1.0"

--- a/frontend/src/components/VerbalPronunciationExercise.tsx
+++ b/frontend/src/components/VerbalPronunciationExercise.tsx
@@ -1,0 +1,115 @@
+import { useLocation, useNavigate } from 'react-router-dom';
+import { Icon } from '@iconify/react';
+import CharacterBadge from '../components/CharacterBadge';
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { speechToText, getAIMarking } from '../logic/sdk';
+import ClipLoader from "react-spinners/ClipLoader";
+
+interface VerbalPronunciationProps {
+    question: string;
+    expected: string;
+    chapter: string;
+    language: string;
+    onQuestionSubmit: Function;
+  }
+
+export default function VerbalPronunciationExercise({question, expected, chapter, language, onQuestionSubmit}: VerbalPronunciationProps) {
+    const location = useLocation();
+    const navigate = useNavigate();
+    const [answered, setAnswered] = useState(false);
+    const [loading, setLoading] = useState(false);
+    const [correct, setCorrect] = useState("");
+    const [reason, setReason] = useState("");
+
+    const handleSubmit = () => {
+        if (answered) {
+            setAnswered(false);
+            onQuestionSubmit();
+        }
+    }
+
+    type Message = { text: string, sender: string };
+    const [isRecording, setIsRecording] = useState(false);
+
+    let chunks = [] as any;
+    const mediaRecorder = useRef<MediaRecorder | null>(null);
+
+    useEffect(() => {
+        navigator.mediaDevices.getUserMedia({ audio: true }).then((stream) => {
+            mediaRecorder.current = new MediaRecorder(stream);
+            mediaRecorder.current.ondataavailable = (e) => {
+                chunks.push(e.data);
+            }
+    
+            mediaRecorder.current.onstop = async (e) => {
+                setIsRecording(false);
+                setLoading(true);
+                const blob = new Blob(chunks, { type: 'audio/wav' });
+                chunks = [];
+            
+                const audioFile = new File([blob], "audio.wav", { type: 'audio/wav' });
+            
+                const text = await speechToText(audioFile);
+                const aiMark = await getAIMarking(question, text.toLowerCase(), expected.toLowerCase(), chapter, language);
+                setAnswered(true);
+                setCorrect(aiMark.correct);
+                setReason(aiMark.reason);
+            }
+        });
+    }, []);
+
+    const handleRecord = useCallback(() => {
+        if (!isRecording) {
+            if (mediaRecorder.current) {
+                mediaRecorder.current.start();
+            }
+            setIsRecording(true);
+        } else {
+            if (mediaRecorder.current) {
+                mediaRecorder.current.stop();
+            }
+        }
+    }, [isRecording]);
+
+    const ResponseSection = (correct: string | null, reason: string | null) => {
+        if (!answered) {
+            return (
+                <div className='flex backdrop:flex-row justify-center w-full'>
+                    <Icon icon="mdi:microphone" className="microphone h-20 w-20 mx-auto"/>
+                    <button className={`record-btn mx-auto ${isRecording ? 'red' : ''}`} onClick={handleRecord}>
+                        {isRecording ? 'Stop Recording' 
+                        : loading ?  
+                        <ClipLoader
+                            color="white"
+                            loading={loading}
+                            aria-label="Loading Spinner"
+                            data-testid="loader"
+                        /> : 
+                        'Record'}
+                    </button>
+                </div>
+
+            )
+        } else {
+            return (
+                <div className=' flex-row flex-wrap w-full'>
+                    <h3>{correct}</h3>
+                    <p>{reason}</p>
+                    <button className='record-btn w-full bottom-0 relative' onClick={(e) => handleSubmit()}>Continue</button>
+                </div>
+            )
+        }
+    }
+
+    return (
+        <div>
+            <div className="v-layout p-10 flex justify-center">
+                <h1 className="text-center">Say the following</h1>
+                <div className='round box h-min no-shadow relative min-h-[60px] flex items-center justify-center'>
+                    {question}
+                </div>
+                {ResponseSection(correct, reason)}
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/components/VerbalQuestionsExercise.tsx
+++ b/frontend/src/components/VerbalQuestionsExercise.tsx
@@ -1,0 +1,117 @@
+import { useState } from 'react';
+import { getAIMarking } from '../logic/sdk';
+import ClipLoader from "react-spinners/ClipLoader";
+import { Icon } from '@iconify/react';
+
+interface VerbalQuestionProps {
+  question: string;
+  wordBank: string[];
+  expected: string;
+  chapter: string;
+  language: string;
+  onQuestionSubmit: Function;
+}
+
+export default function VerbalQuestionsExercise({question, wordBank, expected, chapter, language, onQuestionSubmit}: VerbalQuestionProps) {
+    const [selectedWords, setSelectedWords] = useState<string[]>([]);
+    const [remainingWords, setRemainingWords] = useState(wordBank);
+    const lastPunctuation = question[question.length - 1];
+    const [answered, setAnswered] = useState(false);
+    const [correct, setCorrect] = useState("");
+    const [reason, setReason] = useState("");
+    const [loading, setLoading] = useState(false);
+    const [isListening, setListening] = useState(false);
+
+    const handleWordBankClick = (word: string) => {
+        setSelectedWords([...selectedWords, word]);
+        setRemainingWords(remainingWords.filter((w) => w !== word));
+    }
+
+    const handleSelectedWordClick = (word: string) => {
+        setRemainingWords([...remainingWords, word]);
+        setSelectedWords(selectedWords.filter((w) => w !== word));
+    }
+
+    const handleSubmit = () => {
+        const userAnswer = selectedWords.join(" ") + lastPunctuation;
+        if (answered) {
+            setAnswered(false);
+            onQuestionSubmit();
+        } else {
+            setLoading(true);
+            getAIMarking(
+                question,
+                userAnswer.toLowerCase(),
+                expected.toLowerCase(),
+                chapter,
+                language
+            ).then((res) => {
+                setLoading(false);
+                setAnswered(true);
+                setCorrect(res.correct);
+                setReason(res.reason);
+            }).catch((e) => console.error(e));
+        }
+
+    }
+
+    const ResponseSection = (correct: string | null, reason: string | null) => {
+        if (!answered) {
+            return (
+                <div className='w-full h-36'>
+                    <div className=' flex-row flex-wrap w-full h-full'>
+                        {remainingWords.map((word, index) => (
+                            <span 
+                            key={index} 
+                            className="border-gray-300 border-2 m-1 p-1 px-3 rounded-xl inline-block cursor-pointer"
+                            onClick={(event) => handleWordBankClick(word)}>
+                                {word}
+                            </span>
+                        ))}
+                    </div>
+                    <button className='green' onClick={(e) => handleSubmit()}>
+                        {loading ? <ClipLoader
+                            color="white"
+                            loading={loading}
+                            aria-label="Loading Spinner"
+                            data-testid="loader"
+                        /> : !answered ? "Submit" : "Continue"}
+                    </button>
+                </div>
+
+            )
+        } else {
+            return (
+                <div className=' flex-row flex-wrap border-b-4 w-full h-36'>
+                    <h3>{correct}</h3>
+                    <p>{reason}</p>
+                    <button className='green w-full' onClick={(e) => handleSubmit()}>{!answered ? "Submit" : "Continue"}</button>
+                </div>
+            )
+        }
+    }
+
+    const  handleListenToQuestion = () => {
+        // TODO: Play static file that holds the audio for the current
+        console.log("Heard you");
+    }
+
+    return (
+        <div className='v-layout space-y-8 items-center w-full'>
+            <h1>What do you hear?</h1>
+            <div className='round box h-min no-shadow relative min-h-[60px] flex items-center justify-center mx-5'>
+                <Icon icon="mdi:volume-high" className="volume-high h-16 w-16" onClick={handleListenToQuestion} />
+            </div>
+            <div className='flex-row flex-wrap border-b-4 w-full h-36'>
+                {selectedWords.map((word, index) => (
+                    <span 
+                        key={index}
+                        className="border-gray-300 border-b-2 border-2 m-1 p-1 px-3 rounded-xl inline-block cursor-pointer"
+                        onClick={(e) => handleSelectedWordClick(word)}>
+                        {word}
+                    </span>
+                ))}
+            </div>
+            {ResponseSection(correct, reason)}
+        </div>
+    )}

--- a/frontend/src/components/WrittenQuestionExercise.tsx
+++ b/frontend/src/components/WrittenQuestionExercise.tsx
@@ -56,12 +56,12 @@ export default function WrittenQuestionExercise({question, wordBank, expected, c
     const ResponseSection = (correct: string | null, reason: string | null) => {
         if (!answered) {
             return (
-                <div>
-                    <div className=' flex-row flex-wrap border-b-4 w-full'>
+                <div className='w-full h-36'>
+                    <div className=' flex-row flex-wrap w-full h-full'>
                         {remainingWords.map((word, index) => (
                             <span 
                             key={index} 
-                            className="border-gray-300 border-b-2 border-2 m-1 p-1 px-3 rounded-xl inline-block cursor-pointer"
+                            className="border-gray-300 border-2 m-1 p-1 px-3 rounded-xl inline-block cursor-pointer"
                             onClick={(event) => handleWordBankClick(word)}>
                                 {word}
                             </span>
@@ -80,12 +80,10 @@ export default function WrittenQuestionExercise({question, wordBank, expected, c
             )
         } else {
             return (
-                <div>
-                    <div className=' flex-row flex-wrap border-b-4 w-full'>
-                        <h3>{correct}</h3>
-                        <p>{reason}</p>
-                        <button className='green' onClick={(e) => handleSubmit()}>{!answered ? "Submit" : "Continue"}</button>
-                    </div>
+                <div className=' flex-row flex-wrap border-b-4 w-full h-36'>
+                    <h3>{correct}</h3>
+                    <p>{reason}</p>
+                    <button className='green w-full' onClick={(e) => handleSubmit()}>{!answered ? "Submit" : "Continue"}</button>
                 </div>
             )
         }
@@ -96,7 +94,7 @@ export default function WrittenQuestionExercise({question, wordBank, expected, c
             <div className='round box h-min no-shadow relative min-h-[60px] flex items-center justify-center mx-5'>
                 {question}
             </div>
-            <div className='flex-row flex-wrap border-b-4 w-full'>
+            <div className='flex-row flex-wrap border-b-4 w-full h-36'>
                 {selectedWords.map((word, index) => (
                     <span 
                         key={index}

--- a/frontend/src/components/WrittenVocabularyExercise.tsx
+++ b/frontend/src/components/WrittenVocabularyExercise.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+
+interface WrittenVocabularyProps {
+  question: string;
+  pronunciation: string;
+  definition: string;
+  example: string;
+  onQuestionSubmit: Function;
+}
+
+export default function WrittenQuestionExercise({question, pronunciation, definition, example, onQuestionSubmit}: WrittenVocabularyProps) {
+    const [answered, setAnswered] = useState(false);
+
+    const handleSubmit = () => {
+        if (answered) {
+            setAnswered(false);
+            onQuestionSubmit();
+        } else {
+            setAnswered(true);
+        }
+
+    }
+
+    return (
+        <div className='v-layout space-y-8 items-center w-full'>
+            <h1>Recall Meaning</h1>
+            <div className='round box h-min no-shadow relative min-h-[60px] flex items-center justify-center mx-5'>
+                {question}
+            </div>
+            <div className=' flex-col flex-wrap w-full'>
+                {answered ? 
+                    <div className='flex-col w-full'>
+                        <h3>{pronunciation}</h3>
+                        <p>{definition}</p>
+                        <p>{example}</p>
+                        <div className='flex-row'>
+                            <button className='green my-4' onClick={(e) => handleSubmit()}>I got it!</button>
+                            <button className='red' onClick={(e) => handleSubmit()}>I forgot</button>
+                        </div>
+                    </div>
+                    : 
+                    <button className='white' onClick={(e) => handleSubmit()}>Show Meaning</button>
+                }
+            </div>
+        </div>
+    )}

--- a/frontend/src/components/WrittenVocabularyExercise.tsx
+++ b/frontend/src/components/WrittenVocabularyExercise.tsx
@@ -23,7 +23,6 @@ export default function WrittenQuestionExercise({question, pronunciation, defini
 
     return (
         <div className='v-layout space-y-8 items-center w-full'>
-            <h1>Recall Meaning</h1>
             <div className='round box h-min no-shadow relative min-h-[60px] flex items-center justify-center mx-5'>
                 {question}
             </div>

--- a/frontend/src/pages/Lesson.tsx
+++ b/frontend/src/pages/Lesson.tsx
@@ -1,21 +1,41 @@
 import { useLocation, useNavigate } from 'react-router-dom';
-import { Icon } from '@iconify/react';
 import { useState } from 'react';
 import WrittenQuestionExercise from "../components/WrittenQuestionExercise"
+import Progress from '../components/Progress';
 
 export default function Course() {
     const location = useLocation();
     const navigate = useNavigate();
     const { questions } = location.state;
-    const [currQuestion, setCurrQuestion] = useState(0);
+    const [currQuestion, setCurrQuestion] = useState<number>(0);
 
-    const renderLessonContent = () => {
+    const handleNavigateBack = () => {
+      navigate(-1);
+    };
+
+    const handleQuestionSubmit = () => {
+        if (currQuestion < questions.length - 1) {
+            setCurrQuestion(currQuestion + 1);
+        } else {
+            navigate("/review");
+        }
+  }
+
+    const renderQuestion = (questionIndex: number) => {
       const {question, wordBank, expected, type, exercise} = questions[currQuestion];
         switch (type) {
           case 'written':
             switch (exercise) {
               case 'questions':
-                return <WrittenQuestionExercise question={question} wordBank={wordBank} expected={expected} chapter={"Travel"} language={"Japanese"} setCurrQuestion={setCurrQuestion}/>;
+                return <WrittenQuestionExercise 
+                      key={currQuestion}
+                      question={question} 
+                      wordBank={wordBank} 
+                      expected={expected} 
+                      chapter={"Travel"} 
+                      language={"Japanese"} 
+                      onQuestionSubmit={handleQuestionSubmit}
+                      />;
             //   case 'vocabulary':
             //     return <WrittenVocabularyLesson />;
               default:
@@ -37,10 +57,10 @@ export default function Course() {
     
     return (
         <div className="v-layout p-10">
-            <Icon icon="mdi:arrow-left" className="back-button" onClick={() => navigate(-1)} />
+            <Progress percent={currQuestion / questions.length * 100} back={handleNavigateBack}/>
             <h1 className="text-center">Course Page</h1>
             <div className="flex flex-col flex-1 mb-8 items-center">
-                {renderLessonContent()}
+                {renderQuestion(currQuestion)}
             </div>
         </div>
     )

--- a/frontend/src/pages/Lesson.tsx
+++ b/frontend/src/pages/Lesson.tsx
@@ -4,6 +4,7 @@ import WrittenQuestionExercise from "../components/WrittenQuestionExercise"
 import WrittenVocabularyExercise from "../components/WrittenVocabularyExercise"
 import VerbalQuestionsExercise from "../components/VerbalQuestionsExercise"
 import Progress from '../components/Progress';
+import VerbalPronunciationExercise from '../components/VerbalPronunciationExercise';
 
 export default function Lesson() {
     const location = useLocation();
@@ -50,7 +51,7 @@ export default function Lesson() {
               default:
                 return null;
             }
-          case 'verbal-listening':
+          case 'verbal':
             switch (question.exercise) {
               case 'questions':
                 return <VerbalQuestionsExercise 
@@ -62,8 +63,15 @@ export default function Lesson() {
                 language={"Japanese"} 
                 onQuestionSubmit={handleQuestionSubmit}
                 />;
-        //       case 'pronunciation':
-        //         return <VerbalPronunciationLesson />;
+              case 'pronunciation':
+                return <VerbalPronunciationExercise 
+                key={currQuestion}
+                question={question.question} 
+                expected={question.expected} 
+                chapter={"Travel"} 
+                language={"Japanese"} 
+                onQuestionSubmit={handleQuestionSubmit}
+                />;
               default:
                 return null;
             }

--- a/frontend/src/pages/Lesson.tsx
+++ b/frontend/src/pages/Lesson.tsx
@@ -2,12 +2,13 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 import WrittenQuestionExercise from "../components/WrittenQuestionExercise"
 import WrittenVocabularyExercise from "../components/WrittenVocabularyExercise"
+import VerbalQuestionsExercise from "../components/VerbalQuestionsExercise"
 import Progress from '../components/Progress';
 
-export default function Course() {
+export default function Lesson() {
     const location = useLocation();
     const navigate = useNavigate();
-    const { questions } = location.state;
+    const { questions, home } = location.state;
     const [currQuestion, setCurrQuestion] = useState<number>(0);
 
     const handleNavigateBack = () => {
@@ -18,11 +19,11 @@ export default function Course() {
         if (currQuestion < questions.length - 1) {
             setCurrQuestion(currQuestion + 1);
         } else {
-            navigate("/review");
+            navigate(home);
         }
   }
 
-    const renderQuestion = (questionIndex: number) => {
+    const renderQuestion = (currIndex: number) => {
       const question = questions[currQuestion];
         switch (question.type) {
           case 'written':
@@ -49,17 +50,25 @@ export default function Course() {
               default:
                 return null;
             }
-        //   case 'verbal-listening':
-        //     switch (exercise) {
-        //       case 'questions':
-        //         return <VerbalQuestionsLesson />;
+          case 'verbal-listening':
+            switch (question.exercise) {
+              case 'questions':
+                return <VerbalQuestionsExercise 
+                key={currQuestion}
+                question={question.question} 
+                wordBank={question.wordBank} 
+                expected={question.expected} 
+                chapter={"Travel"} 
+                language={"Japanese"} 
+                onQuestionSubmit={handleQuestionSubmit}
+                />;
         //       case 'pronunciation':
         //         return <VerbalPronunciationLesson />;
-        //       default:
-        //         return null;
-        //     }
-        //   default:
-        //     return null;
+              default:
+                return null;
+            }
+          default:
+            return null;
         }
       };
     

--- a/frontend/src/pages/Lesson.tsx
+++ b/frontend/src/pages/Lesson.tsx
@@ -66,7 +66,6 @@ export default function Course() {
     return (
         <div className="v-layout p-10">
             <Progress percent={currQuestion / questions.length * 100} back={handleNavigateBack}/>
-            <h1 className="text-center">Course Page</h1>
             <div className="flex flex-col flex-1 mb-8 items-center">
                 {renderQuestion(currQuestion)}
             </div>

--- a/frontend/src/pages/Lesson.tsx
+++ b/frontend/src/pages/Lesson.tsx
@@ -1,6 +1,7 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 import WrittenQuestionExercise from "../components/WrittenQuestionExercise"
+import WrittenVocabularyExercise from "../components/WrittenVocabularyExercise"
 import Progress from '../components/Progress';
 
 export default function Course() {
@@ -22,22 +23,29 @@ export default function Course() {
   }
 
     const renderQuestion = (questionIndex: number) => {
-      const {question, wordBank, expected, type, exercise} = questions[currQuestion];
-        switch (type) {
+      const question = questions[currQuestion];
+        switch (question.type) {
           case 'written':
-            switch (exercise) {
+            switch (question.exercise) {
               case 'questions':
                 return <WrittenQuestionExercise 
                       key={currQuestion}
-                      question={question} 
-                      wordBank={wordBank} 
-                      expected={expected} 
+                      question={question.question} 
+                      wordBank={question.wordBank} 
+                      expected={question.expected} 
                       chapter={"Travel"} 
                       language={"Japanese"} 
                       onQuestionSubmit={handleQuestionSubmit}
                       />;
-            //   case 'vocabulary':
-            //     return <WrittenVocabularyLesson />;
+              case 'vocabulary':
+                return <WrittenVocabularyExercise 
+                key={currQuestion}
+                question={question.question}
+                pronunciation={question.pronunciation}
+                definition={question.definition}
+                example={question.example}
+                onQuestionSubmit={handleQuestionSubmit}
+                />;
               default:
                 return null;
             }

--- a/frontend/src/pages/Review.tsx
+++ b/frontend/src/pages/Review.tsx
@@ -1,9 +1,10 @@
-import { useNavigate } from "react-router-dom"
+import { useLocation, useNavigate } from "react-router-dom"
 import NavBar from "../components/NavBar"
 import { getLanguage, getUsername } from "../logic/sdk";
 
 export default function Review() {
     const navigate = useNavigate();
+    const location = useLocation();
 
     const writtenReview = ["Questions", "Vocabulary"];
     const verbalReview = ["Questions", "Pronunciation"];
@@ -81,7 +82,7 @@ export default function Review() {
                         exercise: 'vocabulary',
                     },
                 ];
-                navigate('/lesson', { state: { questions: reviewQuestions } });
+                navigate('/lesson', { state: { questions: reviewQuestions, home: location.pathname } });
             }
         }
     }

--- a/frontend/src/pages/Review.tsx
+++ b/frontend/src/pages/Review.tsx
@@ -13,6 +13,7 @@ export default function Review() {
     const handleReviewLessonClick = (reviewType: string, lesson: string) => {
         type WrittenQuestion = { question: string, wordBank: string[], expected: string, type: string, exercise: string };
         type VocabularyQuestion = { question: string, pronunciation: string, definition: string, example: string, type: string, exercise: string };
+        type VerbalQuestion = { question: string, wordBank: string[], expected: string, type: string, exercise: string };
         if (language === "Japanese") {
             if (reviewType === "written" && lesson === "questions") {
                 let reviewQuestions: WrittenQuestion[] = [];
@@ -37,21 +38,7 @@ export default function Review() {
                         expected: 'I will check in at the hotel.',
                         type: reviewType,
                         exercise: lesson
-                      },
-                      {
-                        question: 'Translate this sentence: 観光名所を訪れます.',
-                        wordBank: ['Desert', 'Mountain', 'Beach', 'Visit', 'Attractions', 'Tourist', 'I', 'Will'],
-                        expected: 'I will visit tourist attractions.',
-                        type: reviewType,
-                        exercise: lesson
-                      },
-                      {
-                        question: 'Translate this sentence: 美味しい地元の食べ物を試します.',
-                        wordBank: ['Try', 'Market', 'Delicious', 'I', 'Food', 'Will', 'River', 'Local', 'Park'],
-                        expected: 'I will try delicious local food.',
-                        type: reviewType,
-                        exercise: lesson
-                      },
+                      }
                 ]
                 navigate('/lesson', { state: { questions: reviewQuestions } });
             } else if (reviewType === "written" && lesson === "vocabulary") {
@@ -82,6 +69,58 @@ export default function Review() {
                         exercise: 'vocabulary',
                     },
                 ];
+                navigate('/lesson', { state: { questions: reviewQuestions, home: location.pathname } });
+            } else if (reviewType === "verbal" && lesson === "questions") {
+                let reviewQuestions: VerbalQuestion[] = [];
+                reviewQuestions = [
+                    {
+                        question: '新幹線で東京に行きます.',
+                        wordBank: ['新', '幹', '線', 'で', '東', '京', 'に', '行', 'き', 'ま', 'す'],
+                        expected: '新幹線で東京に行きます.',
+                        type: reviewType,
+                        exercise: lesson
+                      },
+                      {
+                        question: '空港で荷物を受け取ります.',
+                        wordBank: ['空', '港', 'で', '荷', '物', 'を', '受', 'け', '取', 'り', 'ます', '.'],
+                        expected: '空港で荷物を受け取ります.',
+                        type: reviewType,
+                        exercise: lesson
+                      },
+                      {
+                        question: 'ホテルでチェックインします.',
+                        wordBank: ['ホ', 'テ', 'ル', 'で', 'チ', 'ェ', 'ッ', 'ク', 'イ', 'ン', 'し', 'ま', 'す', '.'],
+                        expected: 'ホテルでチェックインします.',
+                        type: reviewType,
+                        exercise: lesson
+                      }
+                ]; 
+                navigate('/lesson', { state: { questions: reviewQuestions, home: location.pathname } });
+            } else if (reviewType === "verbal" && lesson === "pronunciation") {
+                let reviewQuestions: VerbalQuestion[] = [];
+                reviewQuestions = [
+                    {
+                        question: '新幹線で東京に行きます.',
+                        wordBank: ['新', '幹', '線', 'で', '東', '京', 'に', '行', 'き', 'ま', 'す'],
+                        expected: '新幹線で東京に行きます.',
+                        type: reviewType,
+                        exercise: lesson
+                      },
+                      {
+                        question: '空港で荷物を受け取ります.',
+                        wordBank: ['空', '港', 'で', '荷', '物', 'を', '受', 'け', '取', 'り', 'ます', '.'],
+                        expected: '空港で荷物を受け取ります.',
+                        type: reviewType,
+                        exercise: lesson
+                      },
+                      {
+                        question: 'ホテルでチェックインします.',
+                        wordBank: ['ホ', 'テ', 'ル', 'で', 'チ', 'ェ', 'ッ', 'ク', 'イ', 'ン', 'し', 'ま', 'す', '.'],
+                        expected: 'ホテルでチェックインします.',
+                        type: reviewType,
+                        exercise: lesson
+                      }
+                ]; 
                 navigate('/lesson', { state: { questions: reviewQuestions, home: location.pathname } });
             }
         }

--- a/frontend/src/pages/Review.tsx
+++ b/frontend/src/pages/Review.tsx
@@ -15,36 +15,74 @@ export default function Review() {
         if (language === "Japanese") {
             reviewQuestions = [
                 {
-                    question: 'Translate this sentence: 新幹線で東京に行きます。',
+                    question: 'Translate this sentence: 新幹線で東京に行きます.',
                     wordBank: ['Explore', 'Train', 'Will', 'City', 'I', 'Go', 'Bullet', 'To', 'Tokyo', 'By', 'Mountain'],
                     expected: 'I will go to Tokyo by bullet train.',
                     type: reviewType,
                     exercise: lesson
                   },
                   {
-                    question: 'Translate this sentence: 空港で荷物を受け取ります。',
+                    question: 'Translate this sentence: 空港で荷物を受け取ります.',
                     wordBank: ['Sunset', 'Will', 'Ocean', 'At', 'Adventure', 'Airport', 'The', 'I', 'Receive', 'Luggage'],
                     expected: 'I will receive luggage at the airport.',
                     type: reviewType,
                     exercise: lesson
                   },
                   {
-                    question: 'Translate this sentence: ホテルでチェックインします。',
+                    question: 'Translate this sentence: ホテルでチェックインします.',
                     wordBank: ['Culture', 'At', 'Jungle', 'Will', 'The', 'Check-In', 'Hotel', 'I', 'Historic'],
                     expected: 'I will check in at the hotel.',
                     type: reviewType,
                     exercise: lesson
                   },
                   {
-                    question: 'Translate this sentence: 観光名所を訪れます。',
+                    question: 'Translate this sentence: 観光名所を訪れます.',
                     wordBank: ['Desert', 'Mountain', 'Beach', 'Visit', 'Attractions', 'Tourist', 'I', 'Will'],
                     expected: 'I will visit tourist attractions.',
                     type: reviewType,
                     exercise: lesson
                   },
                   {
-                    question: 'Translate this sentence: 美味しい地元の食べ物を試します。',
+                    question: 'Translate this sentence: 美味しい地元の食べ物を試します.',
                     wordBank: ['Try', 'Market', 'Delicious', 'I', 'Food', 'Will', 'River', 'Local', 'Park'],
+                    expected: 'I will try delicious local food.',
+                    type: reviewType,
+                    exercise: lesson
+                  },
+            ]
+        } else if (language === "Mandarin Chinese") {
+            reviewQuestions = [
+                {
+                    question: 'Translate this sentence: 新幹線で東京に行きます.',
+                    wordBank: ['探索', '列車', '意志', '都市', '私', '行く', '弾丸', 'へ', '東京', 'に', '山'],
+                    expected: 'I will go to Tokyo by bullet train.',
+                    type: reviewType,
+                    exercise: lesson
+                  },
+                  {
+                    question: 'Translate this sentence: 空港で荷物を受け取ります.',
+                    wordBank: ['夕日', '意志', '海洋', 'で', '冒険', '空港', 'の', '私', '受け取る', '荷物'],
+                    expected: 'I will receive luggage at the airport.',
+                    type: reviewType,
+                    exercise: lesson
+                  },
+                  {
+                    question: 'Translate this sentence: ホテルでチェックインします.',
+                    wordBank: ['文化', 'で', 'ジャングル', '意志', 'の', 'チェックイン', 'ホテル', '私', '歴史的'],
+                    expected: 'I will check in at the hotel.',
+                    type: reviewType,
+                    exercise: lesson
+                  },
+                  {
+                    question: 'Translate this sentence: 観光名所を訪れます.',
+                    wordBank: ['砂漠', '山', 'ビーチ', '訪れる', '名所', '観光客', '私', '意志'],
+                    expected: 'I will visit tourist attractions.',
+                    type: reviewType,
+                    exercise: lesson
+                  },
+                  {
+                    question: 'Translate this sentence: 美味しい地元の食べ物を試します.',
+                    wordBank: ['試す', '市場', '美味しい', '私', '食べ物', '意志', '川', '地元', '公園'],
                     expected: 'I will try delicious local food.',
                     type: reviewType,
                     exercise: lesson

--- a/frontend/src/pages/Review.tsx
+++ b/frontend/src/pages/Review.tsx
@@ -10,86 +10,80 @@ export default function Review() {
     const language = getLanguage(getUsername());
 
     const handleReviewLessonClick = (reviewType: string, lesson: string) => {
-        type Question = { question: string, wordBank: string[], expected: string, type: string, exercise: string };
-        let reviewQuestions: Question[] = [];
+        type WrittenQuestion = { question: string, wordBank: string[], expected: string, type: string, exercise: string };
+        type VocabularyQuestion = { question: string, pronunciation: string, definition: string, example: string, type: string, exercise: string };
         if (language === "Japanese") {
-            reviewQuestions = [
-                {
-                    question: 'Translate this sentence: 新幹線で東京に行きます.',
-                    wordBank: ['Explore', 'Train', 'Will', 'City', 'I', 'Go', 'Bullet', 'To', 'Tokyo', 'By', 'Mountain'],
-                    expected: 'I will go to Tokyo by bullet train.',
-                    type: reviewType,
-                    exercise: lesson
-                  },
-                  {
-                    question: 'Translate this sentence: 空港で荷物を受け取ります.',
-                    wordBank: ['Sunset', 'Will', 'Ocean', 'At', 'Adventure', 'Airport', 'The', 'I', 'Receive', 'Luggage'],
-                    expected: 'I will receive luggage at the airport.',
-                    type: reviewType,
-                    exercise: lesson
-                  },
-                  {
-                    question: 'Translate this sentence: ホテルでチェックインします.',
-                    wordBank: ['Culture', 'At', 'Jungle', 'Will', 'The', 'Check-In', 'Hotel', 'I', 'Historic'],
-                    expected: 'I will check in at the hotel.',
-                    type: reviewType,
-                    exercise: lesson
-                  },
-                  {
-                    question: 'Translate this sentence: 観光名所を訪れます.',
-                    wordBank: ['Desert', 'Mountain', 'Beach', 'Visit', 'Attractions', 'Tourist', 'I', 'Will'],
-                    expected: 'I will visit tourist attractions.',
-                    type: reviewType,
-                    exercise: lesson
-                  },
-                  {
-                    question: 'Translate this sentence: 美味しい地元の食べ物を試します.',
-                    wordBank: ['Try', 'Market', 'Delicious', 'I', 'Food', 'Will', 'River', 'Local', 'Park'],
-                    expected: 'I will try delicious local food.',
-                    type: reviewType,
-                    exercise: lesson
-                  },
-            ]
-        } else if (language === "Mandarin Chinese") {
-            reviewQuestions = [
-                {
-                    question: 'Translate this sentence: 新幹線で東京に行きます.',
-                    wordBank: ['探索', '列車', '意志', '都市', '私', '行く', '弾丸', 'へ', '東京', 'に', '山'],
-                    expected: 'I will go to Tokyo by bullet train.',
-                    type: reviewType,
-                    exercise: lesson
-                  },
-                  {
-                    question: 'Translate this sentence: 空港で荷物を受け取ります.',
-                    wordBank: ['夕日', '意志', '海洋', 'で', '冒険', '空港', 'の', '私', '受け取る', '荷物'],
-                    expected: 'I will receive luggage at the airport.',
-                    type: reviewType,
-                    exercise: lesson
-                  },
-                  {
-                    question: 'Translate this sentence: ホテルでチェックインします.',
-                    wordBank: ['文化', 'で', 'ジャングル', '意志', 'の', 'チェックイン', 'ホテル', '私', '歴史的'],
-                    expected: 'I will check in at the hotel.',
-                    type: reviewType,
-                    exercise: lesson
-                  },
-                  {
-                    question: 'Translate this sentence: 観光名所を訪れます.',
-                    wordBank: ['砂漠', '山', 'ビーチ', '訪れる', '名所', '観光客', '私', '意志'],
-                    expected: 'I will visit tourist attractions.',
-                    type: reviewType,
-                    exercise: lesson
-                  },
-                  {
-                    question: 'Translate this sentence: 美味しい地元の食べ物を試します.',
-                    wordBank: ['試す', '市場', '美味しい', '私', '食べ物', '意志', '川', '地元', '公園'],
-                    expected: 'I will try delicious local food.',
-                    type: reviewType,
-                    exercise: lesson
-                  },
-            ]
+            if (reviewType === "written" && lesson === "questions") {
+                let reviewQuestions: WrittenQuestion[] = [];
+                reviewQuestions = [
+                    {
+                        question: 'Translate this sentence: 新幹線で東京に行きます.',
+                        wordBank: ['Explore', 'Train', 'Will', 'City', 'I', 'Go', 'Bullet', 'To', 'Tokyo', 'By', 'Mountain'],
+                        expected: 'I will go to Tokyo by bullet train.',
+                        type: reviewType,
+                        exercise: lesson
+                      },
+                      {
+                        question: 'Translate this sentence: 空港で荷物を受け取ります.',
+                        wordBank: ['Sunset', 'Will', 'Ocean', 'At', 'Adventure', 'Airport', 'The', 'I', 'Receive', 'Luggage'],
+                        expected: 'I will receive luggage at the airport.',
+                        type: reviewType,
+                        exercise: lesson
+                      },
+                      {
+                        question: 'Translate this sentence: ホテルでチェックインします.',
+                        wordBank: ['Culture', 'At', 'Jungle', 'Will', 'The', 'Check-In', 'Hotel', 'I', 'Historic'],
+                        expected: 'I will check in at the hotel.',
+                        type: reviewType,
+                        exercise: lesson
+                      },
+                      {
+                        question: 'Translate this sentence: 観光名所を訪れます.',
+                        wordBank: ['Desert', 'Mountain', 'Beach', 'Visit', 'Attractions', 'Tourist', 'I', 'Will'],
+                        expected: 'I will visit tourist attractions.',
+                        type: reviewType,
+                        exercise: lesson
+                      },
+                      {
+                        question: 'Translate this sentence: 美味しい地元の食べ物を試します.',
+                        wordBank: ['Try', 'Market', 'Delicious', 'I', 'Food', 'Will', 'River', 'Local', 'Park'],
+                        expected: 'I will try delicious local food.',
+                        type: reviewType,
+                        exercise: lesson
+                      },
+                ]
+                navigate('/lesson', { state: { questions: reviewQuestions } });
+            } else if (reviewType === "written" && lesson === "vocabulary") {
+                let reviewQuestions: VocabularyQuestion[] = [];
+                reviewQuestions = [
+                    {
+                        question: '飛行機',
+                        pronunciation: 'ひこうき (Hikouki)',
+                        definition: '飛行機 (Hikouki) is the Japanese word for airplane. It refers to a powered flying vehicle with fixed wings and a weight greater than that of the air it displaces.',
+                        example: '飛行機で旅行します。 (I will travel by airplane.)',
+                        type: 'written',
+                        exercise: 'vocabulary',
+                    },
+                    {
+                        question: '観光',
+                        pronunciation: 'かんこう (Kankou)',
+                        definition: '観光 (Kankou) is the Japanese word for sightseeing. It refers to the activity of visiting places of interest in a particular location, typically as part of a vacation.',
+                        example: '観光地を訪れます。 (I will visit tourist attractions.)',
+                        type: 'written',
+                        exercise: 'vocabulary',
+                    },
+                    {
+                        question: '予約',
+                        pronunciation: 'よやく (Yoyaku)',
+                        definition: '予約 (Yoyaku) is the Japanese word for reservation. It refers to an arrangement for a seat, room, etc. to be kept for a customer at a restaurant, hotel, or other place.',
+                        example: 'ホテルを予約します。 (I will make a hotel reservation.)',
+                        type: 'written',
+                        exercise: 'vocabulary',
+                    },
+                ];
+                navigate('/lesson', { state: { questions: reviewQuestions } });
+            }
         }
-        navigate('/lesson', { state: { questions: reviewQuestions } });
     }
 
     return (
@@ -112,8 +106,8 @@ export default function Review() {
                 {verbalReview.map(lesson => (
                     <button
                         className="white" 
-                        key={"verbal-listening-" + lesson}
-                        onClick={() => handleReviewLessonClick("verbal-listening", lesson.toLowerCase())} 
+                        key={"verbal" + lesson}
+                        onClick={() => handleReviewLessonClick("verbal", lesson.toLowerCase())} 
                     >
                         {lesson}
                     </button>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7905,6 +7905,11 @@ react-scripts@^5.0.1:
   optionalDependencies:
     fsevents "^2.3.2"
 
+react-spinners@^0.13.8:
+  version "0.13.8"
+  resolved "https://registry.yarnpkg.com/react-spinners/-/react-spinners-0.13.8.tgz#5262571be0f745d86bbd49a1e6b49f9f9cb19acc"
+  integrity sha512-3e+k56lUkPj0vb5NDXPVFAOkPC//XyhKPJjvcGjyMNPWsBKpplfeyialP74G7H7+It7KzhtET+MvGqbKgAqpZA==
+
 react@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"


### PR DESCRIPTION
The Review Page takes you to an appropriate lesson for each review type, with dummy questions currently, and only 1 language support (Japanese).

The Written Question and Vocabulary exercises have been implemented, and the Verbal Pronunciation exercise. The Verbal Question exercise has been laid out fully in the UI, but is lacking the text to speech ability to read out the question to the user. This should be done by adding a file path to the pronunciation sound file for every question of this type.

Lastly, to integrate this into the Courses page, all that needs to be done is to navigate to /lesson with the state given with the correct home ("course") and the questions for the lesson.